### PR TITLE
Wip hide dead cells

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -142,12 +142,12 @@ h1 {
     background-color: #444;
 }
 
-.orbitBox {
+.orbitBoxLabel, .hideDeadBoxLabel {
     float: left;
 }
 
-.orbitToggle {
-    display: inline-block;
+.orbitBox, .hideDeadBox {
+    float: right;
 }
 
 .updateButton {

--- a/src/template.html
+++ b/src/template.html
@@ -17,8 +17,13 @@
 		<p id="iterations"></p>
 	</div>
 	<div class="orbitToggle">
-		<label class="orbitBox" for="orbitControls">Orbit Controls:</label>
+		<label class="orbitBoxLabel" for="orbitControls">Orbit Controls:</label>
 		<input class="orbitBox" type="checkbox" id="orbitControls"/><br>
+	</div>
+
+	<div class="hideDeadToggle">
+		<label class="hideDeadBoxLabel" for="hideDeadBox">Hide Dead Cells:</label>
+		<input class="hideDeadBox" type="checkbox" id="hideDeadBox"/><br>
 	</div>
 
 	<label for="presets" class="presetsLabel">Presets:</label>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
 	plugins: [
 		new HtmlWebpackPlugin({
 			title: '3D Game of Life - Samuel Tribe',
-			version: '1.2',
+			version: '1.3 hide-dead',
 			template: path.resolve(__dirname, './src/template.html'),
 			filename: 'index.html',
 			favicon: 'src/assets/images/favicon.ico'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,7 @@ module.exports = {
 	plugins: [
 		new HtmlWebpackPlugin({
 			title: '3D Game of Life - Samuel Tribe',
-			version: '1.3 hide-dead',
+			version: '1.3',
 			template: path.resolve(__dirname, './src/template.html'),
 			filename: 'index.html',
 			favicon: 'src/assets/images/favicon.ico'


### PR DESCRIPTION
Implemented a check box to hide the dead cells, this can improve performance with large numbers of dead cells. Also implemented a basic wireframe cube to represent the boundaries of the grid, this makes it easier to see where the boundaries are, especially when dead cells are hidden.